### PR TITLE
Prevent overwriting passkeys when using registering with the same User ID

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -127,6 +127,20 @@ export default publicAPI;
 async function register(regOptions = regDefaults()) {
 	try {
 		if (supportsWebAuthn) {
+			// ensure credential IDs are binary (not base64 string)
+			if (Array.isArray(regOptions[regOptions[credentialTypeKey]].excludeCredentials)) {
+				regOptions[regOptions[credentialTypeKey]].excludeCredentials = (
+					regOptions[regOptions[credentialTypeKey]].excludeCredentials.map(entry => ({
+						...entry,
+						id: (
+							typeof entry.id == "string" ?
+								sodium.from_base64(entry.id,sodium.base64_variants.ORIGINAL) :
+								entry.id
+						),
+					}))
+				);
+			}
+
 			let regResult = await navigator.credentials.create(regOptions);
 
 			let regClientDataRaw = new Uint8Array(regResult.response.clientDataJSON);

--- a/test/test.js
+++ b/test/test.js
@@ -189,6 +189,18 @@ async function registerNewCredential(name,userIDStr) {
 	}
 	catch (err) {
 		logError(err);
+
+		if (err.cause instanceof Error) {
+			var errorString = err.cause.toString();
+			if (errorString.includes("credentials already registered with the relying party")) {
+				showError(`
+					A credential already exists for this User ID.
+					Please try a different User ID or pick a different authenticator.
+				`);
+				return
+			}
+		} 
+
 		showError("Registering credential failed. Please try again.");
 	}
 }

--- a/test/test.js
+++ b/test/test.js
@@ -136,15 +136,6 @@ async function promptRegister() {
 }
 
 async function registerNewCredential(name,userIDStr) {
-	// check if user already has credentials registered
-	let excludeCredentials = [];
-	if (userIDStr in credentialsByID) {
-		excludeCredentials = credentialsByID[userIDStr].map(({ credentialID }) => ({ 
-			type: "public-key", 
-			id: credentialID, 
-		}));
-	}
-
 	var userID = sodium.from_string(userIDStr);
 	var regOptions = regDefaults({
 		user: {
@@ -152,7 +143,10 @@ async function registerNewCredential(name,userIDStr) {
 			displayName: name,
 			id: userID,
 		},
-		excludeCredentials,
+		excludeCredentials: credentialsByID[userIDStr]?.map(({ credentialID }) => ({ 
+			type: "public-key", 
+			id: credentialID, 
+		})) ?? [],
 	});
 	try {
 		let regResult = await register(regOptions);

--- a/test/test.js
+++ b/test/test.js
@@ -136,6 +136,18 @@ async function promptRegister() {
 }
 
 async function registerNewCredential(name,userIDStr) {
+	// check if user already has credentials registered
+	let excludeCredentials = [];
+	if (userIDStr in credentialsByID) {
+		excludeCredentials = [{
+			type: "public-key", 
+			id: sodium.from_base64(
+				credentialsByID[userIDStr].credentialID,
+				sodium.base64_variants.ORIGINAL
+			)
+		}]
+	}
+
 	var userID = sodium.from_string(userIDStr);
 	var regOptions = regDefaults({
 		user: {
@@ -143,6 +155,7 @@ async function registerNewCredential(name,userIDStr) {
 			displayName: name,
 			id: userID,
 		},
+		excludeCredentials,
 	});
 	try {
 		let regResult = await register(regOptions);


### PR DESCRIPTION
## Issue
Currently, in the test app, if a user registers with the same User ID multiple times, any existing passkeys will the overwritten.

## Changes
When registering a new passkey, send a map of credentials already associated with the user via [`excludeCredentials`](https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer/create#excludecredentials). This will be checked by the user agent to avoid creating a new credential on an authenticator that already has a credential mapped to the specified user.

## Other changes
After making the changes, I ran into another issue-

If a user creates a passkey with one authenticator then creates another passkey on a second authenticator, the credentials stored in `credentialsByID` will be overwritten. To fix this, I updated the `credentialsByID` to store an array of credentials rather than just a single credential.
