### PR TITLE
Fix autofill bug from issue #3

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -377,6 +377,7 @@ async function promptProvideAuth() {
 			catch (err) {
 				logError(err);
 				Swal.showValidationMessage("Oops, authentication didn't work, please try again.");
+				startAuthAutofill().catch(logError);
 				return false;
 			}
 		},


### PR DESCRIPTION
Fixes #3

## Changes

When a user chooses the "Provide my User ID" option, if an error is thrown when user tries authenticating via pasting in their User ID, re-call `startAuthAutofill` so that the passkey autofills are shown again.