### PR TITLE
README: remove defunct/abandoned links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ----
 
-Check out [vella.ai/auth](https://vella.ai/auth/) for a demo app using this library for local-only authentication with WebAuthn and local encryption.
+Check out [next.vella.ai/auth](https://next.vella.ai/auth/) for a demo app using this library for local-only authentication with WebAuthn and local encryption.
 
 [Library Tests (Demo)](https://mylofi.github.io/webauthn-local-client/)
 
@@ -17,7 +17,7 @@ The `WebAuthn` API lets users of web applications avoid the long-troubled use of
 
 However, the intended use-case for **WebAuthn-Local-Client** is to allow [Local-First Web](https://localfirstweb.dev/) applications to handle user login locally on a device, without any server (FIDO2 or otherwise).
 
-**Note:** This package *may* be used in combination with a traditional FIDO2 server application architecture, but does not include any specific functionality for that purpose. For server integration with `WebAuthn`, you may instead consider alternative libraries, like [this one](https://github.com/passwordless-id/webauthn) or [this one](https://github.com/raohwork/webauthn-client).
+**Note:** This package *may* be used in combination with a traditional FIDO2 server application architecture, but does not include any specific functionality for that purpose. For server integration with `WebAuthn`, you may instead consider alternative libraries, like [this one](https://github.com/passwordless-id/webauthn).
 
 ## Deployment / Import
 
@@ -196,7 +196,7 @@ See `authDefaults()` function signature for more options.
 
 `auth()` returns a promise that's fulfilled (success or rejection) once the user completes or cancels a credential (aka "passkey") authentication with their device's authenticator.
 
-If `auth()` completes completes successfully, the return value (`authResult` above) will be an object that includes `request` and `response` properties:
+If `auth()` completes successfully, the return value (`authResult` above) will be an object that includes `request` and `response` properties:
 
 * The `request` property includes all relevant configurations that were applied to the authentication request, and is provided mostly for debugging purposes.
 


### PR DESCRIPTION
i discovered this project thanks to @getify’s interview on the local-first podcast. it’s great! i love the concept, and proper local-first client-only auth is a true breakthrough. finally, something truly _serverless_ (too bad that word means “servers” 🙄). i noticed two things while going through the readme:

1. the main demo link is 404ing, but i was able to use the library tests to demo the functionality very effectively, so i reworked that part of the readme to just point to the library tests.
2. the second link to a library with server integration with `WebAuthn` points to the raohwork/webauthn-client repo, which says that it’s a “WIP Project” and that “It is not tested in any means yet”, but the last commit was more than 5 ½ years ago. that makes me think that it isn’t so WIP any more and has actually been abandoned, so i removed that link.
3. fixed duplicate "completes completes" typo